### PR TITLE
Split word - Change how we determine where a word is "split"

### DIFF
--- a/test_translator.py
+++ b/test_translator.py
@@ -8,21 +8,28 @@ import translator
 
 class TestTranslator(unittest.TestCase):
 
-    def test_IsVowel_vowels(self):
-        self.assertTrue(translator.IsVowel('a'))
-        self.assertTrue(translator.IsVowel('A'))
+    def test_FindSplit_wordsimple(self):
+        self.assertEqual(translator.FindSplit('a'), 0)
+        self.assertEqual(translator.FindSplit('b'), 0)
+        self.assertEqual(translator.FindSplit('test'), 1)
+        self.assertEqual(translator.FindSplit('know'), 2)
 
-    def test_IsVowel_consonants(self):
-        self.assertFalse(translator.IsVowel('b'))
-        self.assertFalse(translator.IsVowel('B'))
+    def test_FindSplit_wordcontains_y(self):
+        self.assertEqual(translator.FindSplit('try'), 2)
+        self.assertEqual(translator.FindSplit('chrysalis'), 3)
+        self.assertEqual(translator.FindSplit('yes'), 1)
+        self.assertEqual(translator.FindSplit('Yvonne'), 0)
 
-    def test_IsVowel_empty(self):
-        self.assertFalse(translator.IsVowel(''))
+    def test_FindSplit_wordcontains_qu(self):
+        self.assertEqual(translator.FindSplit('quit'), 2)
+        self.assertEqual(translator.FindSplit('squishy'), 3)
 
-    def test_IsVowel_nonalpha(self):
-        self.assertFalse(translator.IsVowel(' '))
-        self.assertFalse(translator.IsVowel('-'))
-        self.assertFalse(translator.IsVowel('1'))
+    def test_FindSplit_nonword(self):
+        self.assertEqual(translator.FindSplit(''), 0)
+        self.assertEqual(translator.FindSplit(' '), 0)
+        self.assertEqual(translator.FindSplit('-'), 0)
+        self.assertEqual(translator.FindSplit('1'), 0)
+        self.assertEqual(translator.FindSplit('...)?", '), 0)
 
     def test_Translate_singleword_initialvowel(self):
         self.assertEqual(translator.Translate("aardvark"), "aardvarkway")

--- a/test_translator.py
+++ b/test_translator.py
@@ -10,7 +10,7 @@ class TestTranslator(unittest.TestCase):
 
     def test_FindSplit_wordsimple(self):
         self.assertEqual(translator.FindSplit('a'), 0)
-        self.assertEqual(translator.FindSplit('b'), 0)
+        self.assertEqual(translator.FindSplit('b'), 1)
         self.assertEqual(translator.FindSplit('test'), 1)
         self.assertEqual(translator.FindSplit('know'), 2)
 
@@ -26,10 +26,10 @@ class TestTranslator(unittest.TestCase):
 
     def test_FindSplit_nonword(self):
         self.assertEqual(translator.FindSplit(''), 0)
-        self.assertEqual(translator.FindSplit(' '), 0)
-        self.assertEqual(translator.FindSplit('-'), 0)
-        self.assertEqual(translator.FindSplit('1'), 0)
-        self.assertEqual(translator.FindSplit('...)?", '), 0)
+        self.assertEqual(translator.FindSplit(' '), 1)
+        self.assertEqual(translator.FindSplit('-'), 1)
+        self.assertEqual(translator.FindSplit('1'), 1)
+        self.assertEqual(translator.FindSplit('...)?", '), 8)
 
     def test_Translate_singleword_initialvowel(self):
         self.assertEqual(translator.Translate("aardvark"), "aardvarkway")

--- a/translator.py
+++ b/translator.py
@@ -58,6 +58,8 @@ def TranslateWord(word):
     return translation
 
 
+# Find the "split" point in a word--basically, the first vowely-vowel.  
+# Assumes we've been handed a well-formed word.  
 def FindSplit(word):
 
     i = 0

--- a/translator.py
+++ b/translator.py
@@ -69,3 +69,29 @@ def TranslateWord(word):
 
 def IsVowel(char):
     return char and char.lower() in "aeiouy"
+
+
+def FindSplit(word):
+    split = 0 
+
+    i = 0
+    while i < len(word):
+        # Split at the first vowel found...
+        if word[i].lower() in "aeio":
+            split = i
+            break
+        # ...unless that first vowel happens to be a U following a Q.
+        elif word[i].lower() == 'u':
+            if word[i-1].lower() != 'q':
+                split = i
+                break
+        # Initial Ys are only considered vowels when not followed by another
+        # vowel.
+        elif word[i].lower() == 'y':
+            if i != 0 or word[i + 1].lower() not in "aeiou":
+                split = i
+                break
+
+        i += 1
+
+    return split 

--- a/translator.py
+++ b/translator.py
@@ -39,21 +39,12 @@ def TranslateWord(word):
 
     translation = ""
 
-    stagedConsonants = ""
-    foundVowel = False
+    split = FindSplit(word)
 
-    for c in word:
-        if foundVowel:
-            translation += c
-        else:
-            if IsVowel(c):
-                foundVowel = True
-                translation += c
-            else:
-                stagedConsonants += c
+    translation = word[split:] + word[:split]
 
-    if stagedConsonants:
-        translation += stagedConsonants + "ay"
+    if split > 0:
+        translation += "ay"
     else:
         translation += "way"
 
@@ -67,31 +58,23 @@ def TranslateWord(word):
     return translation
 
 
-def IsVowel(char):
-    return char and char.lower() in "aeiouy"
-
-
 def FindSplit(word):
-    split = 0 
 
     i = 0
     while i < len(word):
         # Split at the first vowel found...
         if word[i].lower() in "aeio":
-            split = i
             break
         # ...unless that first vowel happens to be a U following a Q.
         elif word[i].lower() == 'u':
             if word[i-1].lower() != 'q':
-                split = i
                 break
         # Initial Ys are only considered vowels when not followed by another
         # vowel.
         elif word[i].lower() == 'y':
             if i != 0 or word[i + 1].lower() not in "aeiou":
-                split = i
                 break
 
         i += 1
 
-    return split 
+    return i 


### PR DESCRIPTION
While pondering issue #1 and issue #3, I decided that the "determine vowel-ness letter by letter" was the wrong approach.  At least a couple of special cases needed more nearby-letter context to make the determination.

`IsVowel()` has been replaced with `FindSplit()`.  Rather than doing a simple vowel-comparison, the new function is just a list of hard-coded special cases.  Feels less elegant, but seems more flexible...

(Also, this PR is just a chance for me to play around with github PRs.  I'm much more familiar with Atlassian PRs, so here's a way for me to get familiar without dragging others into it...)